### PR TITLE
[JENKINS-26626] Switch to use BUILD_TIMESTAMP environment variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.410</version>
+        <version>1.597</version>
     </parent>
 
     <artifactId>zentimestamp</artifactId>
@@ -65,6 +65,14 @@
         <connection>scm:git:git://github.com/jenkinsci/zentimestamp-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/zentimestamp-plugin.git</developerConnection>
     </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.3</version>
+        </dependency>
+    </dependencies>
 
     <repositories>
         <repository>

--- a/src/ittest/java/hudson/plugins/zentimestamp/ZenTimestampJobPropertyTest.java
+++ b/src/ittest/java/hudson/plugins/zentimestamp/ZenTimestampJobPropertyTest.java
@@ -4,34 +4,60 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.tasks.Shell;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.text.SimpleDateFormat;
+import java.util.Properties;
 
 
-public class ZenTimestampJobPropertyTest extends HudsonTestCase {
+public class ZenTimestampJobPropertyTest {
+    @Rule public JenkinsRule r = new JenkinsRule();
 
+    @Test
+    public void changeBuildID() throws Exception {
 
-    public void testChangeBuildID() throws Exception {
-
-        final String BUILD_ID = "BUILD_ID";
+        final String BUILD_ID = ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE;
 
         String pattern = "yyyyMMddHHmmss";
 
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         project.getBuildersList().add(new Shell("echo ${" + BUILD_ID + "}"));
         project.addProperty(new ZenTimestampJobProperty(true, pattern));
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();
 
         //Build status
-        assertBuildStatus(Result.SUCCESS, build);
+        r.assertBuildStatus(Result.SUCCESS, build);
 
         //Build log
         SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);
         StringBuffer expectedLog = new StringBuffer().append("echo ").append(dateFormat.format(build.getTime()));
-        assertLogContains(expectedLog.toString(), build);
+        r.assertLogContains(expectedLog.toString(), build);
     }
 
+    @Test
+    @Issue("JENKINS-26626")
+    public void changeTimestampVariable() throws Exception {
+        final String BUILD_ID=ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE;
+
+        String pattern = "yyyyMMddHHmmss";
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.getBuildersList().add(new Shell("echo $BUILD_ID\necho $" + BUILD_ID));
+        p.addProperty(new ZenTimestampJobProperty(true, pattern));
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        r.assertBuildStatus(Result.SUCCESS, build);
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);
+
+        // BUILD_ID should return 1 in newer versions of Jenkins
+        r.assertLogContains("echo 1", build);
+
+        // BUILD_TIMESTAMP now returns the correct build time.
+        r.assertLogContains("echo " + dateFormat.format(build.getTime()), build);
+    }
 
 }

--- a/src/main/java/hudson/plugins/zentimestamp/ZenTimestampAction.java
+++ b/src/main/java/hudson/plugins/zentimestamp/ZenTimestampAction.java
@@ -12,6 +12,8 @@ public class ZenTimestampAction implements EnvironmentContributingAction {
 
     private String pattern;
 
+    public static final String BUILD_TIMESTAMP_VARIABLE="BUILD_TIMESTAMP";
+
     public ZenTimestampAction(String pattern) {
         this.pattern = pattern;
     }
@@ -21,7 +23,7 @@ public class ZenTimestampAction implements EnvironmentContributingAction {
         Calendar buildTimestamp = build.getTimestamp();
         SimpleDateFormat sdf = new SimpleDateFormat(pattern);
         String formattedBUILDID = sdf.format(buildTimestamp.getTime());
-        env.put("BUILD_ID", formattedBUILDID);
+        env.put(BUILD_TIMESTAMP_VARIABLE, formattedBUILDID);
     }
 
     public String getDisplayName() {

--- a/src/main/java/hudson/plugins/zentimestamp/ZenTimestampEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/zentimestamp/ZenTimestampEnvironmentContributor.java
@@ -56,10 +56,10 @@ public class ZenTimestampEnvironmentContributor extends EnvironmentContributor {
         if (pattern != null) {
             final PrintStream logger = listener.getLogger();
             Calendar buildTimestamp = build.getTimestamp();
-            logger.println(String.format("Changing BUILD_ID variable (job build time) with the date pattern %s.", pattern));
+            logger.println(String.format("Changing " + ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE + " variable (job build time) with the date pattern %s.", pattern));
             SimpleDateFormat sdf = new SimpleDateFormat(pattern);
             final String formattedBuildValue = sdf.format(buildTimestamp.getTime());
-            envs.put("BUILD_ID", formattedBuildValue);
+            envs.put(ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE, formattedBuildValue);
         }
     }
 

--- a/src/main/java/hudson/plugins/zentimestamp/ZenTimestampFormatBuildWrapper.java
+++ b/src/main/java/hudson/plugins/zentimestamp/ZenTimestampFormatBuildWrapper.java
@@ -41,7 +41,7 @@ public class ZenTimestampFormatBuildWrapper extends BuildWrapper {
 
         final PrintStream logger = listener.getLogger();
         Calendar buildTimestamp = build.getTimestamp();
-        logger.println("Formating the BUILD_ID variable with'" + pattern + "' pattern.");
+        logger.println("Formating the " + ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE + " variable with'" + pattern + "' pattern.");
         SimpleDateFormat sdf = new SimpleDateFormat(pattern);
         final String newBUILDIDStr = sdf.format(buildTimestamp.getTime());
 
@@ -49,7 +49,7 @@ public class ZenTimestampFormatBuildWrapper extends BuildWrapper {
 
             @Override
             public void buildEnvVars(Map<String, String> env) {
-                env.put("BUILD_ID", newBUILDIDStr);
+                env.put(ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE, newBUILDIDStr);
             }
         };
     }

--- a/src/main/java/hudson/plugins/zentimestamp/ZenTimestampNodeProperty.java
+++ b/src/main/java/hudson/plugins/zentimestamp/ZenTimestampNodeProperty.java
@@ -26,7 +26,7 @@ public class ZenTimestampNodeProperty extends NodeProperty<Node> {
     public static class ZenTimestampNodePropertyDescriptor extends NodePropertyDescriptor {
         @Override
         public String getDisplayName() {
-            return "Date pattern for the BUILD_ID (build timestamp) variable";
+            return "Date pattern for the " + ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE + " (build timestamp) variable";
         }
 
         @Override

--- a/src/main/java/hudson/plugins/zentimestamp/ZenTimestampRunListener.java
+++ b/src/main/java/hudson/plugins/zentimestamp/ZenTimestampRunListener.java
@@ -51,14 +51,14 @@ public class ZenTimestampRunListener extends RunListener<Run> implements Seriali
 
         final PrintStream logger = listener.getLogger();
         Calendar buildTimestamp = build.getTimestamp();
-        logger.println("Formatting the BUILD_ID variable with'" + pattern + "' pattern.");
+        logger.println("Formatting the " + ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE + " variable with'" + pattern + "' pattern.");
         SimpleDateFormat sdf = new SimpleDateFormat(pattern);
         final String formattedBuildValue = sdf.format(buildTimestamp.getTime());
 
         return new Environment() {
             @Override
             public void buildEnvVars(Map<String, String> env) {
-                env.put("BUILD_ID", formattedBuildValue);
+                env.put(ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE, formattedBuildValue);
             }
         };
     }

--- a/src/main/resources/hudson/plugins/zentimestamp/Messages.properties
+++ b/src/main/resources/hudson/plugins/zentimestamp/Messages.properties
@@ -1,3 +1,3 @@
-ZenTimestampFormatBuildWrapper.displayName=Change BUILD_ID format
+ZenTimestampFormatBuildWrapper.displayName=Change BUILD_TIMESTAMP format
 ZenTimestampFormatBuildWrapper.emptyPattern=You must provide a pattern value
 ZenTimestampFormatBuildWrapper.invalidInput=Invalid input {0}

--- a/src/main/resources/hudson/plugins/zentimestamp/ZenTimestampFormatBuildWrapper/help-pattern.html
+++ b/src/main/resources/hudson/plugins/zentimestamp/ZenTimestampFormatBuildWrapper/help-pattern.html
@@ -2,8 +2,7 @@
     <p>
         This wrapper is displayed due to the usage of an old configuration job instance.
         At the next save, the old value will be converted in the new job property value.
-        Attention: Do not try to change the BUILD_ID value here. If you want to change the BUILD_ID value, use the job
-        property
-        section for the plugin.
+        Attention: Do not try to change the BUILD_TIMESTAMP value here. If you want to change the BUILD_TIMESTAMP value, use the job
+        property section for the plugin.
     </p>
 </div>

--- a/src/main/resources/hudson/plugins/zentimestamp/ZenTimestampJobProperty/config.properties
+++ b/src/main/resources/hudson/plugins/zentimestamp/ZenTimestampJobProperty/config.properties
@@ -1,1 +1,1 @@
-BUILDIDOptionLabel=Change date pattern for the BUILD_ID (build timestamp) variable
+BUILDIDOptionLabel=Change date pattern for the BUILD_TIMESTAMP (build timestamp) variable

--- a/src/main/resources/hudson/plugins/zentimestamp/ZenTimestampJobProperty/help-changeBUILDID.html
+++ b/src/main/resources/hudson/plugins/zentimestamp/ZenTimestampJobProperty/help-changeBUILDID.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        The Jenkins BUILD_ID variable uses by default the date and time 'YYYY-MM-DD_hh-mm-ss' of the international
+        The Jenkins BUILD_TIMESTAMP variable uses by default the date and time 'YYYY-MM-DD_hh-mm-ss' of the international
         standard.<br/>
         You can change this format by providing your own pattern.
     </p>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
-  Plugin that allows the customization of the date and time pattern for the Jenkins BUILD_ID variable.
+  Plugin that allows the customization of the date and time pattern for the Jenkins BUILD_TIMESTAMP variable.
 </div>

--- a/src/main/webapp/help-node.html
+++ b/src/main/webapp/help-node.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        The Jenkins BUILD_ID variable uses by default the date and time 'YYYY-MM-DD_hh-mm-ss' of the international
+        The Jenkins BUILD_TIMESTAMP variable uses by default the date and time 'YYYY-MM-DD_hh-mm-ss' of the international
         standard.<br/>
         You can change this format by providing your own pattern for all jobs on this node. <br/>
         You always are able to override the date pattern in your job.


### PR DESCRIPTION
Jenkins `1.597+` now use the `BUILD_ID` variable for holding the build number instead of the timestamp value. This PR is designed to switch the zentimestamp plugin to use environment variable `BUILD_TIMESTAMP` instead.

Also switched to `JenkinsRule` (junit 4+), and added a test unit to confirm old and new behavior.

@reviewbybees
