### PR TITLE
Commented out logging statement

### DIFF
--- a/src/main/java/hudson/plugins/zentimestamp/ZenTimestampEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/zentimestamp/ZenTimestampEnvironmentContributor.java
@@ -56,7 +56,7 @@ public class ZenTimestampEnvironmentContributor extends EnvironmentContributor {
         if (pattern != null) {
             final PrintStream logger = listener.getLogger();
             Calendar buildTimestamp = build.getTimestamp();
-            logger.println(String.format("Changing " + ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE + " variable (job build time) with the date pattern %s.", pattern));
+            //logger.println(String.format("Changing " + ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE + " variable (job build time) with the date pattern %s.", pattern));
             SimpleDateFormat sdf = new SimpleDateFormat(pattern);
             final String formattedBuildValue = sdf.format(buildTimestamp.getTime());
             envs.put(ZenTimestampAction.BUILD_TIMESTAMP_VARIABLE, formattedBuildValue);


### PR DESCRIPTION
Commented out the line that was constantly printing out:

`Changing BUILD_TIMESTAMP variable (job build time) with the date pattern yyyy-MM-dd'T'HH:mm:ss.SSSZ.`

In the console multiple times at the start and also at the end.
